### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = "0.6.0"
 cortex-m-rt = { version = "0.7", optional = true }
-usb-device= "0.2.8"
-usbd-serial = "0.1.1"
-usbd-hid = "0.6.0"
 
 [dev-dependencies]
 panic-halt= "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cytron_maker_pi_rp2040"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["9names"]
 edition = "2021"
 homepage = "https://github.com/9names/makerpi_rp2040"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
-rp2040-hal = "0.5.0"
+rp2040-hal = "0.6.0"
 cortex-m-rt = { version = "0.7", optional = true }
-embedded-time = "0.12.0"
 usb-device= "0.2.8"
 usbd-serial = "0.1.1"
 usbd-hid = "0.6.0"
@@ -24,8 +23,9 @@ usbd-hid = "0.6.0"
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3.0"
-ws2812-pio = "0.3.0"
+ws2812-pio = "0.4.0"
 nb = "1.0"
+fugit = "0.3.6"
 
 [features]
 default = ["boot2", "rt"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find more info about it on the [Maker Pi RP2040 product page](https://ww
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-cytron_maker_pi_rp2040 = "0.3.0"
+cytron_maker_pi_rp2040 = "0.4.0"
 ```
 
 In your program, you will need to call `cytron_maker_pi_rp2040::Pins::new` to create

--- a/examples/cycle_leds.rs
+++ b/examples/cycle_leds.rs
@@ -14,9 +14,6 @@ use cortex_m_rt::entry;
 // GPIO traits
 use embedded_hal::digital::v2::OutputPin;
 
-// Time handling traits
-use embedded_time::rate::*;
-
 use hal::gpio::DynPin;
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)
@@ -69,7 +66,7 @@ fn main() -> ! {
 
     // The delay object lets us wait for specified amounts of time (in
     // milliseconds)
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);

--- a/examples/pwm_buzzer.rs
+++ b/examples/pwm_buzzer.rs
@@ -13,9 +13,6 @@ use cortex_m_rt::entry;
 // GPIO traits
 use embedded_hal::PwmPin;
 
-// Time handling traits
-use embedded_time::rate::*;
-
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)
 use panic_halt as _;
@@ -78,7 +75,7 @@ fn main() -> ! {
 
     // The delay object lets us wait for specified amounts of time (in
     // milliseconds)
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // Init PWMs
     let mut pwm_slices = hal::pwm::Slices::new(pac.PWM, &mut pac.RESETS);

--- a/examples/rgb_leds.rs
+++ b/examples/rgb_leds.rs
@@ -10,7 +10,7 @@
 
 use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
-use embedded_time::duration::Extensions;
+use fugit::ExtU32;
 use panic_halt as _;
 
 // Make an alias for our board support package so copying examples to other boards is easier
@@ -87,7 +87,7 @@ fn main() -> ! {
         ws.write(brightness(leds.iter().cloned(), 32)).unwrap();
         n = n.wrapping_add(1);
 
-        delay.start(25.milliseconds());
+        delay.start(25.millis());
         let _ = nb::block!(delay.wait());
     }
 }

--- a/examples/stepper_motor.rs
+++ b/examples/stepper_motor.rs
@@ -20,9 +20,6 @@ use cortex_m_rt::entry;
 // GPIO traits
 use embedded_hal::digital::v2::OutputPin;
 
-// Time handling traits
-use embedded_time::rate::*;
-
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)
 use panic_halt as _;
@@ -74,7 +71,7 @@ fn main() -> ! {
 
     // The delay object lets us wait for specified amounts of time (in
     // milliseconds)
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);


### PR DESCRIPTION
To update to rp2040-hal 0.6.0 we needed to change to examples to use fugit.
Updated all depenencies and dropped unused ones at the same time.